### PR TITLE
Use primitive `object` type instead of `Object`

### DIFF
--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -5,7 +5,7 @@ const identity = (x: string) => x;
 interface WSOptions {
   jsonProtocol?: boolean;
 }
-export type DeserializedMessage = string | Object;
+export type DeserializedMessage = string | object;
 
 export default class WS {
   server: Server;


### PR DESCRIPTION
I noticed you used `Object`, which is almost never [appropriate](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).

This is b/c `Object` actually refers to the boxed type (i.e the object with functions like `#keys` & `#entities`), rather than "an object".

I didn't feel this was worth an entire issue for a single line change :joy: