### PR TITLE
Add the new T type parameter for Matcher in @types/jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-env": "^7.4.2",
     "@babel/preset-typescript": "^7.3.3",
     "@babel/runtime": "^7.4.2",
-    "@types/jest": "^24.0.11",
+    "@types/jest": "^24.0.22",
     "babel-jest": "^24.5.0",
     "jest": "^24.5.0",
     "mock-socket": "~8.0",

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -4,7 +4,7 @@ import { DeserializedMessage } from "./websocket";
 
 declare global {
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toReceiveMessage<TMessage = object>(
         message: DeserializedMessage<TMessage>
       ): Promise<R>;


### PR DESCRIPTION
Due to [this issue](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39243) the `Matchers` type declaration in this project is no longer compatible with `@types/jest` after `24.0.20`. This results in a `All declarations of 'Matchers' must have identical type parameters.` error when trying to use this project. This PR is to update the usage of `Matchers` to accept the new `T` type parameter and fix the above error.

I've run through all the contribution guidelines and all tests pass. With the package built locally, this also fixes my error.