### PR TITLE
add verifyClient option for mock-socket Server constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,16 @@ server.close();
 WS.clean();
 ```
 
-The `WS` constructor also accepts an optional options object as second argument.
-The only supported option is `jsonProtocol: true`, to tell the mock websocket
-server to automatically serialize and deserialize JSON messages:
+The `WS` constructor also accepts an optional options object as second argument:
+
+- `jsonProtocol: true` can be used to automatically serialize and deserialize JSON messages:
 
 ```js
 const server = new WS("ws://localhost:1234", { jsonProtocol: true });
 server.send({ type: "GREETING", payload: "hello" });
 ```
+
+- The `mock-server` options `verifyClient` and `selectProtocol` are directly passed-through to the mock-server's constructor.
 
 ### Attributes of a `WS` instance
 
@@ -175,12 +177,11 @@ test("the mock server seamlessly handles JSON protocols", async () => {
 A `verifyClient` function can be given in the options for the `jest-websocket-mock` constructor.
 This can be used to test behaviour for a client that connects to a WebSocket server it's blacklisted from for example.
 
-**Note** : _Currently `mock-socket`'s implementation does not send any parameters to this function (unlike the real `ws` implementation. This might be because the check is done in the constructor for a WebSocket client and not on the server side_
+**Note** : _Currently `mock-socket`'s implementation does not send any parameters to this function (unlike the real `ws` implementation)._
 
 ```js
-test("handles the verifyClient option", async () => {
-  const verifyClient = jest.fn().mockReturnValue(false);
-  new WS("ws://localhost:1234", { verifyClient: verifyClient });
+test("rejects connections that fail the verifyClient option", async () => {
+  new WS("ws://localhost:1234", { verifyClient: () => false });
   const errorCallback = jest.fn();
 
   await expect(
@@ -190,18 +191,8 @@ test("handles the verifyClient option", async () => {
       client.onerror = errorCallback;
       client.onopen = resolve;
     })
-  ).rejects.toHaveProperty("type", "error"); // WebSocket onerror event gets called with an event of type error and not an error
-
-  expect(verifyClient).toHaveBeenCalledTimes(1);
-  expect(errorCallback).toHaveBeenCalledTimes(1);
-  expect(errorCallback).toHaveBeenCalledWith(
-    expect.objectContaining({
-      type: "error",
-    })
-  );
-
-  // ensure that the WebSocket mock set up by mock-socket is still present
-  expect(WebSocket).toBeDefined();
+    // WebSocket onerror event gets called with an event of type error and not an error
+  ).rejects.toEqual(expect.objectContaining({ type: "error" }));
 });
 ```
 
@@ -211,9 +202,9 @@ A `selectProtocol` function can be given in the options for the `jest-websocket-
 This can be used to test behaviour for a client that connects to a WebSocket server using the wrong protocol.
 
 ```js
-test("handles the selectProtocol option", async () => {
-  const selectProtocol = jest.fn().mockReturnValue("bar");
-  new WS("ws://localhost:1234", { selectProtocol: selectProtocol });
+test("rejects connections that fail the selectProtocol option", async () => {
+  const selectProtocol = () => null;
+  new WS("ws://localhost:1234", { selectProtocol });
   const errorCallback = jest.fn();
 
   await expect(
@@ -223,36 +214,13 @@ test("handles the selectProtocol option", async () => {
       client.onerror = errorCallback;
       client.onopen = resolve;
     })
-  ).rejects.toHaveProperty("type", "error"); // WebSocket onerror event gets called with an event of type error and not an error
-
-  await expect(
-    new Promise((resolve, reject) => {
-      errorCallback.mockImplementationOnce(reject);
-      const client = new WebSocket("ws://localhost:1234", "bar");
-      client.onerror = errorCallback;
-      client.onopen = resolve;
-    })
-  ).resolves.toHaveProperty("type", "open");
-
-  await expect(
-    new Promise((resolve, reject) => {
-      errorCallback.mockImplementationOnce(reject);
-      const client = new WebSocket("ws://localhost:1234", ["foo", "bar"]);
-      client.onerror = errorCallback;
-      client.onopen = resolve;
-    })
-  ).resolves.toHaveProperty("type", "open");
-
-  expect(selectProtocol).toHaveBeenCalledTimes(3);
-  expect(errorCallback).toHaveBeenCalledTimes(1);
-  expect(errorCallback).toHaveBeenCalledWith(
+  ).rejects.toEqual(
+    // WebSocket onerror event gets called with an event of type error and not an error
     expect.objectContaining({
       type: "error",
+      currentTarget: expect.objectContaining({ protocol: "foo" }),
     })
   );
-
-  // ensure that the WebSocket mock set up by mock-socket is still present
-  expect(WebSocket).toBeDefined();
 });
 ```
 

--- a/src/__tests__/websocket.test.ts
+++ b/src/__tests__/websocket.test.ts
@@ -119,6 +119,35 @@ describe("The WS helper", () => {
     );
   });
 
+  it("handles the verifyClient option", async () => {
+    const verifyClient = jest.fn();
+    verifyClient.mockReturnValueOnce(false).mockReturnValue(true);
+    const server = new WS("ws://localhost:1234", {
+      verifyClient: verifyClient
+    });
+    const client1 = new WebSocket("ws://localhost:1234");
+
+    const errorCallback = jest.fn();
+    client1.onerror = errorCallback;
+
+
+    new WebSocket("ws://localhost:1234"); /* Need something to wait on */
+    await server.connected;
+
+
+
+    expect(verifyClient).toHaveBeenCalledTimes(2);
+    expect(errorCallback).toHaveBeenCalledTimes(1);
+    expect(errorCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error"
+      })
+    );
+
+    // ensure that the WebSocket mock set up by mock-socket is still present
+    expect(WebSocket).toBeDefined();
+  });
+
   it("closes the connection", async () => {
     const server = new WS("ws://localhost:1234");
     const client = new WebSocket("ws://localhost:1234");

--- a/src/__tests__/websocket.test.ts
+++ b/src/__tests__/websocket.test.ts
@@ -123,24 +123,21 @@ describe("The WS helper", () => {
     const verifyClient = jest.fn();
     verifyClient.mockReturnValueOnce(false).mockReturnValue(true);
     const server = new WS("ws://localhost:1234", {
-      verifyClient: verifyClient
+      verifyClient: verifyClient,
     });
     const client1 = new WebSocket("ws://localhost:1234");
 
     const errorCallback = jest.fn();
     client1.onerror = errorCallback;
 
-
     new WebSocket("ws://localhost:1234"); /* Need something to wait on */
     await server.connected;
-
-
 
     expect(verifyClient).toHaveBeenCalledTimes(2);
     expect(errorCallback).toHaveBeenCalledTimes(1);
     expect(errorCallback).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: "error"
+        type: "error",
       })
     );
 

--- a/src/__tests__/websocket.test.ts
+++ b/src/__tests__/websocket.test.ts
@@ -120,20 +120,64 @@ describe("The WS helper", () => {
   });
 
   it("handles the verifyClient option", async () => {
-    const verifyClient = jest.fn();
-    verifyClient.mockReturnValueOnce(false).mockReturnValue(true);
-    const server = new WS("ws://localhost:1234", {
-      verifyClient: verifyClient,
-    });
-    const client1 = new WebSocket("ws://localhost:1234");
-
+    const verifyClient = jest.fn().mockReturnValue(false);
+    new WS("ws://localhost:1234", { verifyClient: verifyClient });
     const errorCallback = jest.fn();
-    client1.onerror = errorCallback;
 
-    new WebSocket("ws://localhost:1234"); /* Need something to wait on */
-    await server.connected;
+    await expect(
+      new Promise((resolve, reject) => {
+        errorCallback.mockImplementation(reject);
+        const client = new WebSocket("ws://localhost:1234");
+        client.onerror = errorCallback;
+        client.onopen = resolve;
+      })
+    ).rejects.toHaveProperty("type", "error"); // WebSocket onerror event gets called with an event of type error and not an error
 
-    expect(verifyClient).toHaveBeenCalledTimes(2);
+    expect(verifyClient).toHaveBeenCalledTimes(1);
+    expect(errorCallback).toHaveBeenCalledTimes(1);
+    expect(errorCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+      })
+    );
+
+    // ensure that the WebSocket mock set up by mock-socket is still present
+    expect(WebSocket).toBeDefined();
+  });
+
+  it("handles the selectProtocol option", async () => {
+    const selectProtocol = jest.fn().mockReturnValue("bar");
+    new WS("ws://localhost:1234", { selectProtocol: selectProtocol });
+    const errorCallback = jest.fn();
+
+    await expect(
+      new Promise((resolve, reject) => {
+        errorCallback.mockImplementationOnce(reject);
+        const client = new WebSocket("ws://localhost:1234", "foo");
+        client.onerror = errorCallback;
+        client.onopen = resolve;
+      })
+    ).rejects.toHaveProperty("type", "error"); // WebSocket onerror event gets called with an event of type error and not an error
+
+    await expect(
+      new Promise((resolve, reject) => {
+        errorCallback.mockImplementationOnce(reject);
+        const client = new WebSocket("ws://localhost:1234", "bar");
+        client.onerror = errorCallback;
+        client.onopen = resolve;
+      })
+    ).resolves.toHaveProperty("type", "open");
+
+    await expect(
+      new Promise((resolve, reject) => {
+        errorCallback.mockImplementationOnce(reject);
+        const client = new WebSocket("ws://localhost:1234", ["foo", "bar"]);
+        client.onerror = errorCallback;
+        client.onopen = resolve;
+      })
+    ).resolves.toHaveProperty("type", "open");
+
+    expect(selectProtocol).toHaveBeenCalledTimes(3);
     expect(errorCallback).toHaveBeenCalledTimes(1);
     expect(errorCallback).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -3,12 +3,11 @@ import Queue from "./queue";
 import act from "./act-compat";
 
 const identity = (x: string) => x;
-interface booleanFunction {
-  (): boolean;
-}
+
 interface WSOptions {
   jsonProtocol?: boolean;
-  verifyClient?: booleanFunction;
+  verifyClient?: () => boolean;
+  selectProtocol?: (protocols: string[]) => string;
 }
 export type DeserializedMessage<TMessage = object> = string | TMessage;
 

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -1,13 +1,11 @@
-import { Server, WebSocket, CloseOptions } from "mock-socket";
+import { Server, WebSocket, ServerOptions, CloseOptions } from "mock-socket";
 import Queue from "./queue";
 import act from "./act-compat";
 
 const identity = (x: string) => x;
 
-interface WSOptions {
+interface WSOptions extends ServerOptions {
   jsonProtocol?: boolean;
-  verifyClient?: () => boolean;
-  selectProtocol?: (protocols: string[]) => string;
 }
 export type DeserializedMessage<TMessage = object> = string | TMessage;
 
@@ -42,7 +40,7 @@ export default class WS {
   constructor(url: string, opts: WSOptions = {}) {
     WS.instances.push(this);
 
-    const { jsonProtocol, ...serverOptions } = opts;
+    const { jsonProtocol = false, ...serverOptions } = opts;
     this.serializer = jsonProtocol ? JSON.stringify : identity;
     this.deserializer = jsonProtocol ? JSON.parse : identity;
 

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -3,8 +3,12 @@ import Queue from "./queue";
 import act from "./act-compat";
 
 const identity = (x: string) => x;
+interface booleanFunction {
+  (): boolean;
+}
 interface WSOptions {
   jsonProtocol?: boolean;
+  verifyClient?: booleanFunction;
 }
 export type DeserializedMessage<TMessage = object> = string | TMessage;
 
@@ -36,9 +40,10 @@ export default class WS {
     WS.instances = [];
   }
 
-  constructor(url: string, { jsonProtocol = false }: WSOptions = {}) {
+  constructor(url: string, opts: WSOptions = {}) {
     WS.instances.push(this);
 
+    const { jsonProtocol, ...serverOptions } = opts;
     this.serializer = jsonProtocol ? JSON.stringify : identity;
     this.deserializer = jsonProtocol ? JSON.parse : identity;
 
@@ -47,7 +52,7 @@ export default class WS {
     this._isConnected = new Promise((done) => (connectionResolver = done));
     this._isClosed = new Promise((done) => (closedResolver = done));
 
-    this.server = new Server(url);
+    this.server = new Server(url, serverOptions);
 
     this.server.on("close", closedResolver);
 


### PR DESCRIPTION
would address https://github.com/romgain/jest-websocket-mock/issues/49

I've followed the contributing readme and there doesn't appear to be any breaking changes from what I've submitted.

if there are cleaner tests or better tests you would suggest I'll try and do what I can