### PR TITLE
Add typing to queue object

### DIFF
--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -24,7 +24,7 @@ export default class WS {
 
   static instances: Array<WS> = [];
   messages: Array<DeserializedMessage> = [];
-  messagesToConsume = new Queue();
+  messagesToConsume = new Queue<DeserializedMessage>();
 
   private _isConnected: Promise<WebSocket>;
   private _isClosed: Promise<{}>;


### PR DESCRIPTION
Was working on #51, and noticed that the queue object does not have a typing. So far, I do not need this type change to complete #51, but I thought it would be nice to have this change from a documentation and a code correctness perspective. It also changes the typing for `nextMessage` from `Promise<unknown>` to `Promise<DeserializedMessage<object>>`.