### PR TITLE
Update jest-diff for jest ^27.0.0 with adding it to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
   },
   "peerDependencies": {
     "mock-socket": "^8||^9"
+  },
+  "dependencies": {
+    "jest-diff": "^27.0.2"
   }
 }

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1,4 +1,4 @@
-import diff from "jest-diff";
+import { diff } from "jest-diff";
 import WS from "./websocket";
 import { DeserializedMessage } from "./websocket";
 


### PR DESCRIPTION
After Jest 27 update commit ([https://github.com/romgain/jest-websocket-mock/commits/master](url)), we need to import diff function without default tag. 
Default import causes:
`diff is not a function at message jest-websocket-mock/lib/jest-websocket-mock.cjs.js`

Becaue of: https://github.com/facebook/jest/pull/11371

To avoid version mismatch, also add jest-diff as a dependency.