### PR TITLE
Add ability to pass custom timeout for the toReceiveMessage

### DIFF
--- a/src/__tests__/matchers.test.ts
+++ b/src/__tests__/matchers.test.ts
@@ -18,6 +18,14 @@ describe(".toReceiveMessage", () => {
     await expect(server).toReceiveMessage("hello there");
   });
 
+  it("passes when the websocket server receives the expected message with custom timeout", async () => {
+    setTimeout(() => {
+      client.send("hello there");
+    }, 2000);
+
+    await expect(server).toReceiveMessage("hello there", { timeout: 3000 });
+  });
+
   it("passes when the websocket server receives the expected JSON message", async () => {
     const jsonServer = new WS("ws://localhost:9876", { jsonProtocol: true });
     const jsonClient = new WebSocket("ws://localhost:9876");
@@ -46,6 +54,18 @@ Received: string
 
 Expected the websocket server to receive a message,
 but it didn't receive anything in 1000ms."
+`);
+  });
+
+  it("fails when the WS server does not receive the expected message with custom timeout", async () => {
+    expect.hasAssertions();
+    await expect(
+      expect(server).toReceiveMessage("hello there", { timeout: 3000 })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+"[2mexpect([22m[31mWS[39m[2m).toReceiveMessage([22m[32mexpected[39m[2m)[22m
+
+Expected the websocket server to receive a message,
+but it didn't receive anything in 3000ms."
 `);
   });
 


### PR DESCRIPTION
Not sure about what you mean in the related issue when you talking about `setWebsocketTime`, because as I know we have to two ways to add custom timeout:

1. Wraps matchers to function which accept global options to customize behavior of the matchers (it will be breaking change); 
2. Adds options for the `toReceiveMessage` matcher.

I implemented second way, but if you see other ways - feel free to discuss

The same approach as RTL https://testing-library.com/docs/dom-testing-library/api-async/#waitfor

Closes #32 