### PR TITLE
Add ability to pass close options to server.error

### DIFF
--- a/src/__tests__/websocket.test.ts
+++ b/src/__tests__/websocket.test.ts
@@ -300,4 +300,25 @@ describe("The WS helper", () => {
 
     expect(socket).toStrictEqual(client);
   });
+
+  it("passes on close options on server error event", async () => {
+    const server = new WS("ws://localhost:1234");
+    const client = new WebSocket("ws://localhost:1234");
+    const closeCallback = jest.fn();
+    await server.connected;
+    client.onclose = closeCallback;
+
+    server.error({ code: 1234, reason: "boom", wasClean: false });
+
+    expect(closeCallback).toHaveBeenCalledTimes(1);
+    expect(closeCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 1234,
+        eventPhase: 0,
+        reason: "boom",
+        type: "close",
+        wasClean: false,
+      })
+    );
+  });
 });

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -115,10 +115,10 @@ export default class WS {
     });
   }
 
-  error() {
+  error(options?: CloseOptions) {
     act(() => {
       this.server.emit("error", null);
     });
-    this.server.close();
+    this.server.close(options);
   }
 }


### PR DESCRIPTION
	- WS.error receives close options as argument and pass it on to WS.close