### PR TITLE
Upgrade `mock-socket` to 9.3.0

### DIFF
--- a/examples/redux-saga/package.json
+++ b/examples/redux-saga/package.json
@@ -40,7 +40,7 @@
     "@testing-library/jest-dom": "^5.11.0",
     "@testing-library/react": "^10.4.6",
     "@testing-library/user-event": "^12.0.11",
-    "mock-socket": "^9.0.3"
+    "mock-socket": "^9.3.0"
   },
   "peerDependencies": {
     "jest-websocket-mock": "~2.0"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
   },
   "dependencies": {
     "jest-diff": "^29.2.0",
-    "mock-socket": "^9.1.0"
+    "mock-socket": "^9.3.0"
   }
 }


### PR DESCRIPTION
Contains an important fix that prevents `send()` from _throwing_ exceptions when the socket is in the `CLOSING` or `CLOSED` state. This makes the mock more closely imitate the browser.

https://github.com/thoov/mock-socket/pull/382