### PR TITLE
Upgrade `mock-socket` to 9.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
   },
   "dependencies": {
     "jest-diff": "^29.2.0",
-    "mock-socket": "^9.3.0"
+    "mock-socket": "^9.3.1"
   }
 }


### PR DESCRIPTION
This version fixes a bug where the `open` event would fire despite the socket having been closed while in the `CONNECTING` state.

See https://github.com/thoov/mock-socket/pull/383