### PR TITLE
Add new "toReceiveMessage" matcher that checks all sent messages instead of next message

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ A `WS` instance has the following attributes:
 `jest-websocket-mock` registers custom jest matchers to make assertions
 on received messages easier:
 
-- `.toReceiveMessage`: async matcher that waits for the next message received
+- `.toReceiveMessage`: async matcher that waits 1000ms for the the mock websocket
+  server to receive the expected message. It will time out with a helpful
+  message after 1000ms.
+- `.toReceiveMessageNext`: async matcher that waits for the next message received
   by the the mock websocket server, and asserts its content. It will time out
   with a helpful message after 1000ms.
 - `.toHaveReceivedMessages`: synchronous matcher that checks that all the

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -24,7 +24,7 @@ export default class WS {
 
   static instances: Array<WS> = [];
   messages: Array<DeserializedMessage> = [];
-  messagesToConsume = new Queue();
+  messagesToConsume = new Queue<DeserializedMessage>();
 
   private _isConnected: Promise<Client>;
   private _isClosed: Promise<{}>;


### PR DESCRIPTION
Fixes #51

Finally got around to this. This is what I'm thinking of for the new `toReceiveMessage` matcher, as we discussed before.

Here are some example failure messages:

### Wrong message received

```
expect(WS).toReceiveMessage(expected)

Expected the following message within 1000ms:
  "PRIVMSG #mychannel :Not the message"
but instead received the following messages:
  ["PASS mypass", "NICK coteh", "USER coteh 0 * :James", "PRIVMSG #mychannel :Hello there"]

Difference:

- Expected
+ Received

  Array [
-   "PRIVMSG #mychannel :Not the message",
+   "PASS mypass",
+   "NICK coteh",
+   "USER coteh 0 * :James",
+   "PRIVMSG #mychannel :Hello there",
  ]
```

### Message never received

```
expect(WS).toReceiveMessage(expected)

Expected the following message within 1000ms:
  "PRIVMSG #mychannel :Hello there"
but instead received the following messages:
  ["PASS mypass", "NICK coteh", "USER coteh 0 * :James"]

Difference:

- Expected
+ Received

  Array [
-   "PRIVMSG #mychannel :Hello there",
+   "PASS mypass",
+   "NICK coteh",
+   "USER coteh 0 * :James",
  ]
```

### Nothing was received at all

```
expect(WS).toReceiveMessage(expected)

Expected the following message within 1000ms:
  "PRIVMSG #mychannel :Hello there"
but it didn't receive anything.
```

Let me know your thoughts. If you think it looks good and can still benefit the project, I'll take this out of draft, polish it up a bit, and apply any feedback you may have. Thanks!
